### PR TITLE
Added optional modular slot id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.0.2
+## 16/03/2016
+
+1. [](#new)
+  * Added optional modular slot id
+  * Fixed a bug with sandbox mode
+
 # v1.0.1
 ## 05/12/2015
 

--- a/adsense.php
+++ b/adsense.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * AdSense v1.0.1
+ * AdSense v1.0.2
  *
  * This plugin enables to use AdSense inside a document
  * to be rendered by Grav.
@@ -9,7 +9,7 @@
  * http://cookie-soft.de/license
  *
  * @package     AdSense
- * @version     1.0.1
+ * @version     1.0.2
  * @link        <https://github.com/muuvmuuv/grav-plugin-adsense>
  * @author      Marvin Heilemann <marvin.heilemann@cookie-soft.de>
  * @copyright   2015, Marvin Heilemann

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: "AdSense"
-version: 1.0.1
+version: 1.0.2
 description: "This plugin enables to use AdSense inside a document to be rendered by Grav."
 icon: adn
 author:


### PR DESCRIPTION
Now it is possible to give a modular a slot id. This is optional so you still can use on slot id in the default adsense settings.

Sorry for the bad pr but I definitely cant handle git ...